### PR TITLE
Fix chromium executable path detection

### DIFF
--- a/html2img/server.js
+++ b/html2img/server.js
@@ -18,10 +18,15 @@ if (!fs.existsSync(OUTPUT_DIR)) {
 }
 
 // ✅ RPi5 環境專用：舊版 headless 模式 + chromium 路徑
+// 依序嘗試不同的 chromium 執行檔路徑
+const CHROMIUM_PATH = fs.existsSync('/usr/bin/chromium')
+  ? '/usr/bin/chromium'
+  : '/usr/bin/chromium-browser';
+
 async function getBrowser() {
   return await puppeteer.launch({
     headless: 'old',
-    executablePath: '/usr/bin/chromium', // 或 '/usr/bin/chromium-browser'，取決於 Dockerfile 安裝的實際路徑
+    executablePath: CHROMIUM_PATH,
     args: [
       '--no-sandbox',
       '--disable-setuid-sandbox',
@@ -141,3 +146,4 @@ app.listen(PORT, () => {
   console.log(`🚀 html2img server 已啟動：port ${PORT}`);
   console.log(`💾 Output directory mounted at: ${OUTPUT_DIR}`);
 });
+


### PR DESCRIPTION
## Summary
- update `server.js` to auto-detect available chromium executable

## Testing
- `npm start` *(fails: chromium snap not installed)*
- `curl -X POST http://localhost:3000/render ...` *(fails: chromium snap not installed)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6840361c96bc83219df8721d28439190