### PR TITLE
Fix font loading for weather card images

### DIFF
--- a/html2img/server.js
+++ b/html2img/server.js
@@ -54,7 +54,8 @@ async function getBrowser() {
       '--disable-gpu',
       '--single-process',
       '--no-zygote',
-      '--disable-web-security'
+      '--disable-web-security',
+      '--allow-file-access-from-files'
     ]
   });
 }

--- a/line_webhook/line_webhook_app.py
+++ b/line_webhook/line_webhook_app.py
@@ -1588,7 +1588,7 @@ def build_weather_aqi_html(weather: dict, aqi: dict) -> str:
       <style>
         @font-face {{
             font-family: "TaiwanPearl";
-            src: url("file:///ttf/PopGothicCjkTc-Regular.ttf");
+            src: url("file:///ttf/TaiwanPearl-Medium.ttf");
             font-weight: normal;
             font-style: normal;
         }}


### PR DESCRIPTION
## Summary
- allow file access in Puppeteer so local fonts load properly
- update weather card HTML to use TaiwanPearl font from the `ttf` folder

## Testing
- `python -m py_compile line_webhook/line_webhook_app.py`
- `node -c html2img/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68429d4052148321a2016c08f7f831a9