### PR TITLE
Add Wantgoo index screenshot and weekly archive

### DIFF
--- a/line_webhook/line_webhook_app.py
+++ b/line_webhook/line_webhook_app.py
@@ -928,6 +928,9 @@ def capture_wantgoo_index_chart() -> Optional[str]:
     import uuid
     out_filename = f"wantgoo_{uuid.uuid4().hex}.png"
     out_path = os.path.join(SHARED_DIR, out_filename)
+    # Ensure Playwright can locate its browser binaries even if HOME is unset
+    if not os.environ.get("PLAYWRIGHT_BROWSERS_PATH"):
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "/root/.cache/ms-playwright"
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch(

--- a/line_webhook/plot_twse_intraday.py
+++ b/line_webhook/plot_twse_intraday.py
@@ -25,6 +25,11 @@ df = pd.read_csv(CSV_PATH)
 today = datetime.datetime.now().strftime("%Y-%m-%d")
 df = df[df["datetime"].str.startswith(today)]
 
+# 若沒有任何今日成交資料，直接結束避免後續錯誤
+if df.empty or df["price"].dropna().empty:
+    print("No intraday data available for plotting.")
+    raise SystemExit(0)
+
 # 轉成datetime格式
 df["datetime"] = pd.to_datetime(df["datetime"])
 

--- a/line_webhook/plot_twse_intraday.py
+++ b/line_webhook/plot_twse_intraday.py
@@ -16,6 +16,9 @@ SHARED_DIR = os.getenv("SHARED_DIR", "/shared")
 CSV_PATH = os.path.join(SHARED_DIR, "twse_intraday.csv")
 OUT_PATH = os.path.join(SHARED_DIR, "twse_intraday.png")
 
+if not os.path.exists(CSV_PATH):
+    CSV_PATH = os.path.join(os.path.dirname(__file__), "twse_intraday.csv")
+
 df = pd.read_csv(CSV_PATH)
 
 # 只保留今天的資料


### PR DESCRIPTION
## Summary
- add a function to capture WantGoo weighted index chart using Playwright
- include WantGoo chart image in the "盤子" command reply
- archive generated images weekly instead of daily

## Testing
- `python3 -m py_compile line_webhook/line_webhook_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847b5d2e5a083218cd2f7ecc9c0c72b