### PR TITLE
Fix fallback paths and playwright config

### DIFF
--- a/line_webhook/line_webhook_app.py
+++ b/line_webhook/line_webhook_app.py
@@ -928,6 +928,9 @@ def capture_wantgoo_index_chart() -> Optional[str]:
     import uuid
     out_filename = f"wantgoo_{uuid.uuid4().hex}.png"
     out_path = os.path.join(SHARED_DIR, out_filename)
+    # Ensure Playwright can locate its browser binaries even if HOME is unset
+    if not os.environ.get("PLAYWRIGHT_BROWSERS_PATH"):
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "/root/.cache/ms-playwright"
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch(

--- a/line_webhook/plot_twse_intraday.py
+++ b/line_webhook/plot_twse_intraday.py
@@ -16,6 +16,9 @@ SHARED_DIR = os.getenv("SHARED_DIR", "/shared")
 CSV_PATH = os.path.join(SHARED_DIR, "twse_intraday.csv")
 OUT_PATH = os.path.join(SHARED_DIR, "twse_intraday.png")
 
+if not os.path.exists(CSV_PATH):
+    CSV_PATH = os.path.join(os.path.dirname(__file__), "twse_intraday.csv")
+
 df = pd.read_csv(CSV_PATH)
 
 # 只保留今天的資料


### PR DESCRIPTION
## Summary
- handle missing intraday data csv by falling back to bundled file
- ensure Playwright browser path is set when capturing WantGoo chart

## Testing
- `python3 -m py_compile line_webhook/plot_twse_intraday.py line_webhook/line_webhook_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847bd574e3c8321a912acb9a9c07e67